### PR TITLE
[SG-1000] Allow setting the foreground color used in text mode.

### DIFF
--- a/SGlib/src/SGlib.c
+++ b/SGlib/src/SGlib.c
@@ -178,7 +178,7 @@ void SG_init (void) {
 }
 
 void SG_setBackdropColor (unsigned char entry) {
-  SG_write_to_VDPRegister (0x07, entry & 0x0f);
+  SG_write_to_VDPRegister (0x07, entry);
 }
 
 void SG_setSpriteMode (unsigned char mode) {


### PR DESCRIPTION
Register 7 can also contain a foreground color when in text mode. In other modes the upper bits are ignored.