### PR TITLE
Add an assets2banks.py option to exclude files

### DIFF
--- a/assets2banks/README.md
+++ b/assets2banks/README.md
@@ -3,12 +3,14 @@
 ### How to use assets2banks
 
 ```
-assets2banks <asset folder> [--firstbank=<number>[,<size>]][--compile][--singleheader[=<filename>]]
+assets2banks <asset folder> [--firstbank=<number>[,<size>]][--compile][--singleheader[=<filename>]][--exclude=<filename>]
 ```
 
 Using the assets2banks utility you can create .c source files and their respective .h header files containing one constant data array for each single file found in the specified asset folder.
 (Adding --singleheader you'll generate a single assets2banks.h file (or any name you prefer giving to it) instead of one single .h header file for each bank)
 Also, if you add the --compile option to your command line, object files (RELs) will be generated in place of the C source files, so you won't have to compile them yourself.
+
+If the asset folder contains files you wish assets2banks to ignore (for instance, a file called .gitignore) you can exclude each file using the --exclude option.
 
 Example usage:
 

--- a/assets2banks/src/assets2banks.py
+++ b/assets2banks/src/assets2banks.py
@@ -87,12 +87,13 @@ def find(fun, seq):
             return item
 
 def print_usage():
-    print("Usage: assets2banks path [--firstbank=<number>[,<size>]][--compile][--singleheader[=<filename>]]")
+    print("Usage: assets2banks path [--firstbank=<number>[,<size>]][--compile][--singleheader[=<filename>]][--exclude=<filename>]")
     sys.exit(1)
 
 AssetGroupList = []    # list of the groups (we will sort this)
 AssetList = []         # list of the assets (for inspection)
 BankList = []          # list of the banks
+ExcludeList = []       # list of files to exclude
 
 print("*** sverx's assets2banks converter ***")
 
@@ -150,6 +151,8 @@ for n, arg in enumerate(sys.argv):
             single_h = 1
             single_h_filename = "assets2banks.h"
             print("Info: single header file requested (assets2banks.h)")
+        elif arg[:10] == "--exclude=":
+            ExcludeList.append(arg[10:])
         else:
             print("Fatal: invalid '{0!s}' parameter".format(arg))
             print_usage()
@@ -238,6 +241,8 @@ except (IOError, OSError):
 
 try:
     for f in os.listdir(assets_path):  # read directory content and create missing assets and assetgroup (one per asset)
+        if f in ExcludeList:
+            continue
         if os.path.isfile(os.path.join(assets_path, f)):
             st = os.stat(os.path.join(assets_path, f))
             a = Asset(str(f), st.st_size)


### PR DESCRIPTION
In some projects, the assets folder may contain files that should
not be included. For instance, the folder could contain a .gitignore
file which has no business ending up in the ROM.