### PR TITLE
Add SMS_saveROMBank() and SMS_restoreROMBank()

### DIFF
--- a/SMSlib/src/SMSlib.h
+++ b/SMSlib/src/SMSlib.h
@@ -59,6 +59,16 @@ void SMS_setSpriteMode (unsigned char mode) __z88dk_fastcall;
 volatile __at (0xffff) unsigned char ROM_bank_to_be_mapped_on_slot2;
 #define SMS_mapROMBank(n)       ROM_bank_to_be_mapped_on_slot2=(n)
 
+/* macros to preserve and restore the currently mapped ROM bank */
+
+/* Typical use: In functions using SMS_mapROMBank(), to make sure the mapped bank */
+/* when entering the function is unchanged upon return. */
+/* Use only one SMS_saveROMBank() before the first SMS_mapROMBank() in the function, */
+/* and at least one SMS_restoreROMBank() per following return statement. */
+/* SMS_restoreROMBank() may be used several times, for instance to access data in the original bank. */
+#define SMS_saveROMBank()       unsigned char _saved_slot2_ROM_bank = ROM_bank_to_be_mapped_on_slot2
+#define SMS_restoreROMBank()    SMS_mapROMBank(_saved_slot2_ROM_bank)
+
 /* macro for SRAM access */
 volatile __at (0xfffc) unsigned char SRAM_bank_to_be_mapped_on_slot2;
 #define SMS_enableSRAM()        SRAM_bank_to_be_mapped_on_slot2=0x08


### PR DESCRIPTION
Typical use: In functions using SMS_mapROMBank(), to make sure the mapped bank
when entering the function is unchanged upon return.

Use only one SMS_saveROMBank() before the first SMS_mapROMBank() in the function,
and at least one SMS_restoreROMBank() per following return statement.

SMS_restoreROMBank() may be used several times, for instance to access data in the original bank.