### PR TITLE
Add support for a vblank interrupt hook

### DIFF
--- a/SMSlib/src/Makefile
+++ b/SMSlib/src/Makefile
@@ -17,6 +17,10 @@ AR=sdar
 # Build a lib supporting less sprites to save memory. Default 64 (all).
 #CONFIG+=-DMAXSPRITES=64
 
+# Build a lib supporting frame interrupt hooks. (Function called fater
+# SMS_isr has done its housekeeping)
+#CONFIG+=-DFRAME_INT_HOOK
+
 ############# END OF BUILD CONFIG OPTIONS #############
 
 OPT=--max-allocs-per-node 100000

--- a/SMSlib/src/SMSlib.h
+++ b/SMSlib/src/SMSlib.h
@@ -266,6 +266,13 @@ extern volatile unsigned char SMS_VDPFlags;
 
 extern unsigned char SMS_Port3EBIOSvalue;
 
+/* vertical interrupt hook */
+#ifdef FRAME_INT_HOOK
+/* If non-NULL, the specified function will be called by SMS_isr after acknowledging */
+/* the interrupt and reading controller status. */
+void SMS_setFrameInterruptHandler (void (*theHandlerFunction)(void)) __z88dk_fastcall;
+#endif
+
 /* line interrupt */
 void SMS_setLineInterruptHandler (void (*theHandlerFunction)(void)) __z88dk_fastcall;
 void SMS_setLineCounter (unsigned char count) __z88dk_fastcall;


### PR DESCRIPTION
If support is compiled into the library, SMS_setFrameInterruptHandler()
can be used to set a function to be called at the end of the built-in
interrupt handler (i.e. called after the interrupt has been acknowledged
and controller status updated)