### PR TITLE
Add support for large songs spawning multiple banks

### DIFF
--- a/PSGlib/README.md
+++ b/PSGlib/README.md
@@ -4,10 +4,14 @@ PSGlib
 these are the currently defined functions/macros:
 
 ```
+
 void PSGPlay (void *song);                           /* this will make your PSG tune start and loop forever */
 void PSGPlayLoops (void *song, unsigned char loops); /* this will make your PSG tune start and loop the requested amount of times*/
-void PSGCancelLoop (void);                           /* tell the library to stop the tune at next loop */
 void PSGPlayNoRepeat (void *song);                   /* this will make your PSG tune start and stop at loop */
+
+
+
+void PSGCancelLoop (void);                           /* tell the library to stop the tune at next loop */
 void PSGStop (void);                                 /* this will make your PSG tune stop (pause) */
 void PSGResume (void);                               /* this will make your stopped (paused) PSG tune resume playing */
 unsigned char PSGGetStatus (void);                   /* get the current status of the tune */
@@ -27,3 +31,35 @@ void PSGFrame (void);                           /* you should call this at a con
 void PSGSFXFrame (void);                        /* you should call this too at a constant pace, if you use SFXs */
 ```
 
+Multibank support
+-----------------
+
+If PSGlib is compiled with PSGLIB_MULTIBANK, the PSGPlay functions
+also take a bank argument. This initial bank is rememberd by
+PSGlib and the bank will be switched automatically when calling
+PSGFrame().
+
+PSGlib will automatically switch bank if the song data occupies
+more than 16kB, but it is assumed that the data is not segmented.
+(i.e. it must be consecutive in ROM)
+
+When PSGFrame() returns, the current bank in slot 2 may have
+been changed, so keep this in mind and take the necessary
+steps if necessary. (Set the bank again after the call, or
+use SMS_saveROMBank/restoreROMBank)
+
+When NOT compiled with PSGLIB_MULTIBANK, you must
+set the correct bank before calling PSGFrame manually and
+the song data cannot exceed 16kB.
+
+```
+/* Only if the library is compiled with PSGLIB_MULTIBANK.
+ * Make sure to define PSGLIB_MULTIBANK before including
+ * PSGlib.h
+ */
+
+void PSGPlay (void *song, unsigned char bank);                           /* this will make your PSG tune start and loop forever */
+void PSGPlayLoops (void *song, unsigned char bank, unsigned char loops); /* this will make your PSG tune start and loop the requested amount of times*/
+void PSGPlayNoRepeat (void *song, unsigned char bank);                   /* this will make your PSG tune start and stop at loop */
+
+```

--- a/PSGlib/src/Makefile
+++ b/PSGlib/src/Makefile
@@ -32,7 +32,7 @@ PSGlib.rel: PSGlib.c PSGlib.h
 	$(CC) $(CFLAGS) $(PEEP_OPTIONS) -c -o $@ $<
 
 PSGlib_multibank.rel: PSGlib.c PSGlib.h
-	$(CC) $(CFLAGS) $(PEEP_OPTIONS) -c -o $@ $< -DMULTIBANK
+	$(CC) $(CFLAGS) $(PEEP_OPTIONS) -c -o $@ $< -DPSGLIB_MULTIBANK
 
 # Default rules
 %.rel: %.c SMSlib.h peep-rules.txt

--- a/PSGlib/src/Makefile
+++ b/PSGlib/src/Makefile
@@ -1,0 +1,43 @@
+CC=sdcc
+AR=sdar
+
+########### BUILD CONFIGURATION ##############
+
+
+############# END OF BUILD CONFIG OPTIONS #############
+OPT=
+CFLAGS=-mz80 $(OPT) $(CONFIG)
+PEEP_OPTIONS=
+
+OUTPUT_LIBS=PSGlib.lib PSGlib_multibank.lib
+
+# One .rel per common source file. Add target specific .rel dependencies here.
+OBJS_STD=PSGlib.rel
+OBJS_MB=PSGlib_multibank.rel
+
+ALL: $(OUTPUT_LIBS)
+
+# Library outputs
+PSGlib.lib: $(OBJS_STD)
+	sdar r $@ $^
+
+PSGlib_multibank.lib: $(OBJS_MB)
+	sdar r $@ $^
+
+
+# Specific rules for some files with particular compilation options or specific
+# to a target.
+
+PSGlib.rel: PSGlib.c PSGlib.h
+	$(CC) $(CFLAGS) $(PEEP_OPTIONS) -c -o $@ $<
+
+PSGlib_multibank.rel: PSGlib.c PSGlib.h
+	$(CC) $(CFLAGS) $(PEEP_OPTIONS) -c -o $@ $< -DMULTIBANK
+
+# Default rules
+%.rel: %.c SMSlib.h peep-rules.txt
+	$(CC) $(CFLAGS) $(PEEP_OPTIONS) -c -o $@ $<
+
+clean:
+	rm -f $(OUTPUT_LIBS) $(OBJS_STD) $(OBJS_MB) *.lst *.sym *.asm
+

--- a/PSGlib/src/PSGlib.c
+++ b/PSGlib/src/PSGlib.c
@@ -495,7 +495,7 @@ _substring:
   ld hl,(_PSGMusicStart)
   add hl,bc                           ; make substring current
 #ifdef MULTIBANK
-  ; Restrict to slot 2 (bit 16 set, bit 15 cleared)
+  ; Restrict to slot 2 (bit 15 set, bit 14 cleared)
   set 7, h
   res 6, h
 

--- a/PSGlib/src/PSGlib.c
+++ b/PSGlib/src/PSGlib.c
@@ -552,11 +552,10 @@ _PSG_ReadByte_C:
   ld c,(hl)                      ; load PSG byte (in C)
   inc hl                         ; point to next byte
   bit 6,h
-  jp z, _nobankchangeC
+  ret z
   res 6,h                        ; Reset the bit (back to slot 2)
   inc a                          ; And advance to next bank
   ld (_PSGMusicPointerBank), a   ; Save new bank
-_nobankchangeC:
   ret
 
 

--- a/PSGlib/src/PSGlib.c
+++ b/PSGlib/src/PSGlib.c
@@ -539,7 +539,7 @@ _PSG_ReadByte_B:
   ld b,(hl)                      ; load PSG byte (in B)
   inc hl                         ; point to next byte
   bit 6,h
-  ret z, _nobankchange
+  ret z
   res 6,h                        ; Reset the bit (back to slot 2)
   inc a                          ; And advance to next bank
   ld (_PSGMusicPointerBank), a   ; Save new bank

--- a/PSGlib/src/PSGlib.c
+++ b/PSGlib/src/PSGlib.c
@@ -539,11 +539,10 @@ _PSG_ReadByte_B:
   ld b,(hl)                      ; load PSG byte (in B)
   inc hl                         ; point to next byte
   bit 6,h
-  jp z, _nobankchange
+  ret z, _nobankchange
   res 6,h                        ; Reset the bit (back to slot 2)
   inc a                          ; And advance to next bank
   ld (_PSGMusicPointerBank), a   ; Save new bank
-_nobankchange:
   ret
 
  // Same as above, but to C

--- a/PSGlib/src/PSGlib.h
+++ b/PSGlib/src/PSGlib.h
@@ -10,6 +10,24 @@
 #define SFX_CHANNEL3        #0x02
 #define SFX_CHANNELS2AND3   SFX_CHANNEL2|SFX_CHANNEL3
 
+/* About multi bank support
+ *
+ * If PSGlib is compiled with MULTIBANK, the current bank in slot 2
+ * will be remembered by PSGlib and the bank will be switched
+ * automatically when calling PSGFrame(), but you must still take care
+ * of switching to the correct bank before calling PSGPlay, PSGPlayLoops
+ * or PSGPlayNoRepeat.
+ *
+ * PSGlib will automatically switch banks if the song data occupies more
+ * than 16kB, but it is assumed that the data is not segmented. (i.e.
+ * consecutive in ROM)
+ *
+ * Make sure to save/restore the bank in slot 2 before calling
+ * PSGFrame(), as bank 2 will change.
+ *
+ * (SMS_saveROMBank/restoreROMBank can help here!)
+ */
+
 void PSGPlay (void *song);
 void PSGPlayLoops (void *song, unsigned char loops);
 void PSGCancelLoop (void);

--- a/PSGlib/src/PSGlib.h
+++ b/PSGlib/src/PSGlib.h
@@ -12,26 +12,35 @@
 
 /* About multi bank support
  *
- * If PSGlib is compiled with MULTIBANK, the current bank in slot 2
- * will be remembered by PSGlib and the bank will be switched
- * automatically when calling PSGFrame(), but you must still take care
- * of switching to the correct bank before calling PSGPlay, PSGPlayLoops
- * or PSGPlayNoRepeat.
+ * If PSGlib is compiled with PSGLIB_MULTIBANK, the PSGPlayX functions
+ * also take a bank argument. This initial bank is remembered by
+ * PSGlib and the bank will be switched automatically when calling
+ * PSGFrame().
  *
- * PSGlib will automatically switch banks if the song data occupies more
- * than 16kB, but it is assumed that the data is not segmented. (i.e.
- * consecutive in ROM)
+ * PSGlib will automatically switch bank if the song data occupies
+ * more than 16kB, but it is assumed that the data is not segmented.
+ * (i.e. it must be consecutive in ROM)
  *
- * Make sure to save/restore the bank in slot 2 before calling
- * PSGFrame(), as bank 2 will change.
+ * When PSGFrame() returns, the current bank in slot 2 may have
+ * been changed, so keep this in mind and take the necessary
+ * steps if necessary. (Set the bank again after the call, or
+ * use SMS_saveROMBank/restoreROMBank)
  *
- * (SMS_saveROMBank/restoreROMBank can help here!)
+ * When NOT compiled with PSGLIB_MULTIBANK, you must
+ * set the correct bank before calling PSGFrame manually and
+ * the song data cannot exceed 16kB.
  */
 
+#ifdef PSGLIB_MULTIBANK
+void PSGPlay (void *song, unsigned char bank);
+void PSGPlayLoops (void *song, unsigned char loops, unsigned char bank);
+void PSGPlayNoRepeat (void *song, unsigned char bank);
+#else
 void PSGPlay (void *song);
 void PSGPlayLoops (void *song, unsigned char loops);
-void PSGCancelLoop (void);
 void PSGPlayNoRepeat (void *song);
+#endif
+void PSGCancelLoop (void);
 void PSGStop (void);
 void PSGResume (void);
 unsigned char PSGGetStatus (void);


### PR DESCRIPTION
Long songs can easily grow past 16kB, and this happened to me yesterday (my song is 24kB), so I had to do something.

My solution was to add support for multi-bank playback to PSGlib. The requirement is simply that the song data be consecutive in ROM. PSGlib takes care of increasing the bank and restraining the song pointer to slot 2.

In theory the limit in size is now 64kB if the song is compressed (substring offset is 16 bit), but I suspect this could be worked around by not compressing or only using substrings within the first 64kB, etc.

I added some documentation to the .h:

```
/* About multi bank support
 *
 * If PSGlib is compiled with MULTIBANK, the current bank in slot 2
 * will be remembered by PSGlib and the bank will be switched
 * automatically when calling PSGFrame(), but you must still take care
 * of switching to the correct bank before calling PSGPlay, PSGPlayLoops
 * or PSGPlayNoRepeat.
 *
 * PSGlib will automatically switch banks if the song data occupies more
 * than 16kB, but it is assumed that the data is not segmented. (i.e.
 * consecutive in ROM)
 *
 * Make sure to save/restore the bank in slot 2 before calling
 * PSGFrame(), as bank 2 will change.
 *
 * (SMS_saveROMBank/restoreROMBank can help here!)
 */
```

