### PR TITLE
Asset splitting

### DIFF
--- a/assets2banks/src/assets2banks.py
+++ b/assets2banks/src/assets2banks.py
@@ -96,7 +96,7 @@ ExcludeList = []       # list of files to exclude
 
 print("*** sverx's assets2banks converter ***")
 
-if 2 <= len(sys.argv) <= 5:
+if 2 <= len(sys.argv):
     assets_path = sys.argv[1]
     first_bank = 2                                                  # first bank will be number 2
     compile_rel = 0                                                 # RELs not requested


### PR DESCRIPTION
If --allowsplitting is passed on the command-line, when an asset larger than 16kB is encountered, instead of generating an error, assets2banks will split it in multiple 16kB chunks and place those in consecutive banks. All parts will end up being consecutive in ROM.

The string "_PARTx" where x is the part number (starting at 0)
will be appended to the default resource name.

For instance, bigfile would be declared as

bigfile_PART0
bigfile_PART1
