### PR TITLE
Fix the putchar() function

### DIFF
--- a/SMSlib/src/SMSlib_textrenderer.c
+++ b/SMSlib/src/SMSlib_textrenderer.c
@@ -2,7 +2,7 @@
    SMSlib - C programming library for the SMS/GG
    ( part of devkitSMS - github.com/sverx/devkitSMS )
    ************************************************** */
-
+#include <stdio.h>
 #include "SMSlib.h"
 #include "SMSlib_common.c"
 
@@ -12,6 +12,6 @@ void SMS_configureTextRenderer (signed int ascii_to_tile_offset) __z88dk_fastcal
   SMS_TextRenderer_offset=ascii_to_tile_offset;
 }
 
-void putchar (char c) {
+int putchar (int c) {
   SMS_setTile(c+SMS_TextRenderer_offset);
 }


### PR DESCRIPTION
In SMSlib, putchar() was implemented as void putchar(char). However,
SDCC defines putchar() as extern "int putchar(int)" in stdio.h, and
this is where user code gets the function prototype from.

With the new ABI this is a problem, since the caller puts the character
value in HL because it is 16 bits, but compiled code in SMSlib expects
it in A since it is 8 bit...

With this patch it is now working again.

I include <stdio.h> so the compiler will issue a warning or
error if the definition in stdio.h ever changes, though it is not
likely...