### PR TITLE
Workaround compilation bug - likely faster implementation now too

### DIFF
--- a/SMSlib/src/SMSlib_loadTileMapArea.c
+++ b/SMSlib/src/SMSlib_loadTileMapArea.c
@@ -9,20 +9,18 @@
 void SMS_loadTileMapArea (unsigned char x, unsigned char y, const void *src, unsigned char width, unsigned char height) {
   unsigned char sz = width * 2;
   const char *data = (const char *)src;
-  unsigned char skip = 64 - width * 2;
   unsigned int vdp_addr;
 
   vdp_addr = SMS_PNTAddress+(y*32+x)*2;
 
-  y = height;
   do {
     SMS_setAddr(vdp_addr);
-	x = sz;
-	do {
-	    VDPDataPort=*(data++);
-	} while(--x);
 
-	data += skip;
-	vdp_addr += 64;
-  } while(--y);
+    x = sz;
+    do {
+      VDPDataPort=*(data++);
+    } while(--x);
+
+    vdp_addr += 64;
+  } while(--height);
 }

--- a/SMSlib/src/SMSlib_loadTileMapArea.c
+++ b/SMSlib/src/SMSlib_loadTileMapArea.c
@@ -7,11 +7,22 @@
 #include "SMSlib_common.c"
 
 void SMS_loadTileMapArea (unsigned char x, unsigned char y, const void *src, unsigned char width, unsigned char height) {
-  unsigned char cur_y;
-  for (cur_y=y;cur_y<y+height;cur_y++) {
-    // SMS_set_address_VRAM(SMS_PNTAddress+(cur_y*32+x)*2);
-    SMS_setAddr(SMS_PNTAddress+(cur_y*32+x)*2);
-    SMS_byte_brief_array_to_VDP_data(src,width*2);
-    src=(unsigned char*)src+width*2;
-  }
+  unsigned char sz = width * 2;
+  const char *data = (const char *)src;
+  unsigned char skip = 64 - width * 2;
+  unsigned int vdp_addr;
+
+  vdp_addr = SMS_PNTAddress+(y*32+x)*2;
+
+  y = height;
+  do {
+    SMS_setAddr(vdp_addr);
+	x = sz;
+	do {
+	    VDPDataPort=*(data++);
+	} while(--x);
+
+	data += skip;
+	vdp_addr += 64;
+  } while(--y);
 }


### PR DESCRIPTION
SDCC 4.2.0 apparently does not compile SMS_loadTileMapArea correctly.
When building the lib with this version of SDCC, it appears to copy a
wider than expecter area, but the generated asm is too confusing for
me to understanding it, track down the problem and create a simple
test case to submit a bug...

Suspecting it may have had something to do with the presence of an inline
function, I tried inlining it manually - but ended up changing how
things are done quite a bit. And it does work finally!
(I can build SMSlib and my project with SDCC 4.2.0 at last)

Though I do not have measurements, I think this, while a lot less compact
in terms of code lines, is a faster implementation since the calculation
of the target VRAM address is done only once outside the loop now.
(I confirmed by comparing the assembly generated before and after my changes)