### PR TITLE
Introduce SMS_putchar and SMS_printstring

### DIFF
--- a/SMSlib/README.md
+++ b/SMSlib/README.md
@@ -77,6 +77,7 @@ void SMS_configureTextRenderer (signed int ascii_to_tile_offset);  /* set the va
 void SMS_autoSetUpTextRenderer (void);                             /* load a standard font character set into tiles 0-95, set BG palette to B/W and turn on the screen */
 void SMS_putchar (char c);                                         /* faster than plain putchar() */
 void SMS_printstring (const char *str);                            /* faster than printf() for unformatted strings */
+SMS_printStringatXY(x,y,s);                                        /* macro - prints a string starting at X/Y */
 
 /* decompress ZX7-compressed data to RAM */
 void SMS_decompressZX7 (void *src, void *dst);

--- a/SMSlib/README.md
+++ b/SMSlib/README.md
@@ -75,6 +75,8 @@ void SMS_copySpritestoSAT (void);           /* copy sprites to Sprites Attribute
 /* text renderer */
 void SMS_configureTextRenderer (signed int ascii_to_tile_offset);  /* set the value you should add to ASCII value to get the tile number */
 void SMS_autoSetUpTextRenderer (void);                             /* load a standard font character set into tiles 0-95, set BG palette to B/W and turn on the screen */
+void SMS_putchar (char c);                                         /* faster than plain putchar() */
+void SMS_printstring (const char *str);                            /* faster than printf() for unformatted strings */
 
 /* decompress ZX7-compressed data to RAM */
 void SMS_decompressZX7 (void *src, void *dst);

--- a/SMSlib/README.md
+++ b/SMSlib/README.md
@@ -76,8 +76,8 @@ void SMS_copySpritestoSAT (void);           /* copy sprites to Sprites Attribute
 void SMS_configureTextRenderer (signed int ascii_to_tile_offset);  /* set the value you should add to ASCII value to get the tile number */
 void SMS_autoSetUpTextRenderer (void);                             /* load a standard font character set into tiles 0-95, set BG palette to B/W and turn on the screen */
 void SMS_putchar (char c);                                         /* faster than plain putchar() */
-void SMS_printstring (const char *str);                            /* faster than printf() for unformatted strings */
-SMS_printStringatXY(x,y,s);                                        /* macro - prints a string starting at X/Y */
+void SMS_print(const char *str);                                   /* faster than printf() for unformatted strings */
+SMS_printatXY(x,y,s);                                              /* macro - prints a string starting at X/Y */
 
 /* decompress ZX7-compressed data to RAM */
 void SMS_decompressZX7 (void *src, void *dst);

--- a/SMSlib/src/Makefile
+++ b/SMSlib/src/Makefile
@@ -30,7 +30,7 @@ PEEP_OPTIONS=--peep-file peep-rules.txt
 OUTPUT_LIBS=SMSlib.lib SMSlib_GG.lib
 
 # Files that are compiled once and used for SMS and GG
-SRCS=SMSlib_aPLib.c SMSlib_autotext.c SMSlib_deprecated.c SMSlib_load1bppTiles.c SMSlib_loadTileMapArea.c SMSlib_paddle.c SMSlib_paletteAdv.c SMSlib_PSGaiden.c  SMSlib_spriteAdv.c SMSlib_sprite.c SMSlib_STMcomp.c SMSlib_textrenderer.c SMSlib_threesprites.c SMSlib_twosprites.c SMSlib_UNSAFE.c SMSlib_UNSAFE_zx7.c SMSlib_VRAMmemcpy_brief.c SMSlib_VRAMmemcpy.c SMSlib_VRAMmemset.c SMSlib_zx7.c
+SRCS=SMSlib_aPLib.c SMSlib_autotext.c SMSlib_deprecated.c SMSlib_load1bppTiles.c SMSlib_loadTileMapArea.c SMSlib_paddle.c SMSlib_paletteAdv.c SMSlib_PSGaiden.c  SMSlib_spriteAdv.c SMSlib_sprite.c SMSlib_STMcomp.c SMSlib_textrenderer.c SMSlib_threesprites.c SMSlib_twosprites.c SMSlib_UNSAFE.c SMSlib_UNSAFE_zx7.c SMSlib_VRAMmemcpy_brief.c SMSlib_VRAMmemcpy.c SMSlib_VRAMmemset.c SMSlib_zx7.c SMSlib_string.c
 
 # One .rel per common source file. Add target specific .rel dependencies here.
 OBJS_SMS=$(patsubst %.c,%.rel,$(SRCS)) SMSlib.rel SMSlib_autotext.rel SMSlib_spriteClip.rel

--- a/SMSlib/src/SMSlib.h
+++ b/SMSlib/src/SMSlib.h
@@ -212,6 +212,8 @@ void SMS_zeroSpritePalette (void);
 /* text renderer */
 void SMS_configureTextRenderer (signed int ascii_to_tile_offset) __z88dk_fastcall;
 void SMS_autoSetUpTextRenderer (void);
+void SMS_putchar (char c);              /* faster than plain putchar() */
+void SMS_printstring (const char *str); /* faster than printf() for unformatted strings */
 
 /* decompress ZX7-compressed data to RAM */
 void SMS_decompressZX7 (const void *src, void *dst) __naked __sdcccall(1);

--- a/SMSlib/src/SMSlib.h
+++ b/SMSlib/src/SMSlib.h
@@ -212,10 +212,10 @@ void SMS_zeroSpritePalette (void);
 /* text renderer */
 void SMS_configureTextRenderer (signed int ascii_to_tile_offset) __z88dk_fastcall;
 void SMS_autoSetUpTextRenderer (void);
-void SMS_putchar (unsigned char c);              /* faster than plain putchar() */
-void SMS_printstring (const unsigned char *str); /* faster than printf() for unformatted strings */
+void SMS_putchar (unsigned char c);         /* faster than plain putchar() */
+void SMS_print (const unsigned char *str);  /* faster than printf() for unformatted strings */
 /* Macro to print a string at a given location */
-#define SMS_printStringatXY(x,y,s) do { SMS_setNextTileatXY(x,y); SMS_printstring(s); } while(0)
+#define SMS_printatXY(x,y,s) do { SMS_setNextTileatXY(x,y); SMS_print(s); } while(0)
 
 
 /* decompress ZX7-compressed data to RAM */

--- a/SMSlib/src/SMSlib.h
+++ b/SMSlib/src/SMSlib.h
@@ -212,8 +212,11 @@ void SMS_zeroSpritePalette (void);
 /* text renderer */
 void SMS_configureTextRenderer (signed int ascii_to_tile_offset) __z88dk_fastcall;
 void SMS_autoSetUpTextRenderer (void);
-void SMS_putchar (char c);              /* faster than plain putchar() */
-void SMS_printstring (const char *str); /* faster than printf() for unformatted strings */
+void SMS_putchar (unsigned char c);              /* faster than plain putchar() */
+void SMS_printstring (const unsigned char *str); /* faster than printf() for unformatted strings */
+/* Macro to print a string at a given location */
+#define SMS_printStringatXY(x,y,s) do { SMS_setNextTileatXY(x,y); SMS_printstring(s); } while(0)
+
 
 /* decompress ZX7-compressed data to RAM */
 void SMS_decompressZX7 (const void *src, void *dst) __naked __sdcccall(1);

--- a/SMSlib/src/SMSlib_string.c
+++ b/SMSlib/src/SMSlib_string.c
@@ -12,7 +12,7 @@ void SMS_putchar (unsigned char c) {
   SMS_setTile(c+SMS_TextRenderer_offset);
 }
 
-void SMS_printstring (const unsigned char *str) {
+void SMS_print (const unsigned char *str) {
   // If using SMS_TextRenderer_offset directly, SDCC
   // ends up loading it from memory inside the loop.
   //

--- a/SMSlib/src/SMSlib_string.c
+++ b/SMSlib/src/SMSlib_string.c
@@ -8,11 +8,11 @@
 
 extern signed int SMS_TextRenderer_offset;
 
-void SMS_putchar (char c) {
+void SMS_putchar (unsigned char c) {
   SMS_setTile(c+SMS_TextRenderer_offset);
 }
 
-void SMS_printstring (const char *str) {
+void SMS_printstring (const unsigned char *str) {
   // If using SMS_TextRenderer_offset directly, SDCC
   // ends up loading it from memory inside the loop.
   //

--- a/SMSlib/src/SMSlib_string.c
+++ b/SMSlib/src/SMSlib_string.c
@@ -1,0 +1,28 @@
+/* **************************************************
+   SMSlib - C programming library for the SMS/GG
+   ( part of devkitSMS - github.com/sverx/devkitSMS )
+   ************************************************** */
+#include <stdio.h>
+#include "SMSlib.h"
+#include "SMSlib_common.c"
+
+extern signed int SMS_TextRenderer_offset;
+
+void SMS_putchar (char c) {
+  SMS_setTile(c+SMS_TextRenderer_offset);
+}
+
+void SMS_printstring (const char *str) {
+  // If using SMS_TextRenderer_offset directly, SDCC
+  // ends up loading it from memory inside the loop.
+  //
+  // The register keyword does not make a difference, but
+  // it does capture the intention...
+  register int off = SMS_TextRenderer_offset;
+
+  while (*str) {
+    SMS_setTile(*str + off);
+    str++;
+  }
+}
+

--- a/SMSlib/src/how to build this.txt
+++ b/SMSlib/src/how to build this.txt
@@ -51,6 +51,9 @@ sdcc -o SMSlib_PSGaiden.rel -c -mz80 %OPT% --peep-file peep-rules.txt SMSlib_PSG
 sdcc -o SMSlib_textrenderer.rel -c -mz80 %OPT% --peep-file peep-rules.txt SMSlib_textrenderer.c
 @if %errorlevel% NEQ 0 goto :EOF
 
+sdcc -o SMSlib_textrenderer.rel -c -mz80 %OPT% --peep-file peep-rules.txt SMSlib_string.c
+@if %errorlevel% NEQ 0 goto :EOF
+
 sdcc -o SMSlib_autotext.rel -c -mz80 %OPT% --peep-file peep-rules.txt SMSlib_autotext.c
 @if %errorlevel% NEQ 0 goto :EOF
 


### PR DESCRIPTION
SMS_putchar is faster than standard putchar since it has no return value and takes a char instead of an int.

SMS_printstring is for printing strings. Faster than printf as there is no formatting.