### PR TITLE
Add basic read from VRAM functionality

### DIFF
--- a/SMSlib/src/Makefile
+++ b/SMSlib/src/Makefile
@@ -30,7 +30,7 @@ PEEP_OPTIONS=--peep-file peep-rules.txt
 OUTPUT_LIBS=SMSlib.lib SMSlib_GG.lib
 
 # Files that are compiled once and used for SMS and GG
-SRCS=SMSlib_aPLib.c SMSlib_autotext.c SMSlib_deprecated.c SMSlib_load1bppTiles.c SMSlib_loadTileMapArea.c SMSlib_paddle.c SMSlib_paletteAdv.c SMSlib_STC0comp.c SMSlib_PSGaiden.c  SMSlib_spriteAdv.c SMSlib_sprite.c SMSlib_STMcomp.c SMSlib_textrenderer.c SMSlib_threesprites.c SMSlib_twosprites.c SMSlib_UNSAFE.c SMSlib_UNSAFE_zx7.c SMSlib_VRAMmemcpy_brief.c SMSlib_VRAMmemcpy.c SMSlib_VRAMmemset.c SMSlib_zx7.c SMSlib_string.c
+SRCS=SMSlib_aPLib.c SMSlib_autotext.c SMSlib_deprecated.c SMSlib_load1bppTiles.c SMSlib_loadTileMapArea.c SMSlib_paddle.c SMSlib_paletteAdv.c SMSlib_STC0comp.c SMSlib_PSGaiden.c  SMSlib_spriteAdv.c SMSlib_sprite.c SMSlib_STMcomp.c SMSlib_textrenderer.c SMSlib_threesprites.c SMSlib_twosprites.c SMSlib_UNSAFE.c SMSlib_UNSAFE_zx7.c SMSlib_VRAMmemcpy_brief.c SMSlib_VRAMmemcpy.c SMSlib_VRAMmemset.c SMSlib_zx7.c SMSlib_string.c SMSlib_readVRAM.c
 
 # One .rel per common source file. Add target specific .rel dependencies here.
 OBJS_SMS=$(patsubst %.c,%.rel,$(SRCS)) SMSlib.rel SMSlib_autotext.rel SMSlib_spriteClip.rel

--- a/SMSlib/src/SMSlib.h
+++ b/SMSlib/src/SMSlib.h
@@ -147,6 +147,12 @@ void SMS_loadSTMcompressedTileMapatAddr (unsigned int dst, const void *src);
 #define SMS_loadSTMcompressedTileMapArea(x,y,src,w) SMS_loadSTMcompressedTileMapatAddr(XYtoADDR((x),(y)),(src))
 // SMS_loadSTMcompressedTileMapArea *DEPRECATED* - will be dropped at some point in 2018
 
+/* Functions for reading back tilemap and VRAM */
+/* PNT define for reading */
+#define SMS_PNTAddress_r           (SMS_PNTAddress & 0x3FFF)
+unsigned short SMS_getTile(void) __z88dk_fastcall __naked;
+void SMS_saveTileMapArea(unsigned char x, unsigned char y, void *dst, unsigned char width, unsigned char height);
+
 /* ***************************************************************** */
 /* Sprites handling                                                  */
 /* ***************************************************************** */

--- a/SMSlib/src/SMSlib_readVRAM.c
+++ b/SMSlib/src/SMSlib_readVRAM.c
@@ -1,0 +1,38 @@
+/* **************************************************
+   SMSlib - C programming library for the SMS/GG
+   ( part of devkitSMS - github.com/sverx/devkitSMS )
+   ************************************************** */
+#include "SMSlib.h"
+
+void SMS_saveTileMapArea(unsigned char x, unsigned char y, void *dst, unsigned char width, unsigned char height)
+{
+    unsigned char i,j;
+    unsigned short *d = dst;
+
+    for (i=0; i<height; i++) {
+        SMS_setAddr(SMS_PNTAddress_r + (y + i) * 64 + x * 2);
+        for (j=0; j<width; j++) {
+            *d++ = SMS_getTile();
+        }
+    }
+}
+
+#pragma save
+#pragma disable_warning 85
+
+unsigned short SMS_getTile(void) __z88dk_fastcall __naked
+{
+    __asm
+
+    in a, (#0xBE)  ; 13
+    ld l, a        ; 4
+    inc hl         ; 11
+    dec hl         ; 11
+    in a, (#0xBE)  ; 13
+    ld h, a        ; 4
+    ret
+
+    __endasm;
+}
+
+#pragma restore

--- a/SMSlib/src/SMSlib_readVRAM.c
+++ b/SMSlib/src/SMSlib_readVRAM.c
@@ -24,11 +24,11 @@ unsigned short SMS_getTile(void) __z88dk_fastcall __naked
 {
     __asm
 
-    in a, (#0xBE)  ; 13
+    in a, (#0xBE)  ; 11
     ld l, a        ; 4
-    inc hl         ; 11
-    dec hl         ; 11
-    in a, (#0xBE)  ; 13
+    inc hl         ; 6
+    dec hl         ; 6
+    in a, (#0xBE)  ; 11
     ld h, a        ; 4
     ret
 

--- a/SMSlib/src/how to build this.txt
+++ b/SMSlib/src/how to build this.txt
@@ -54,6 +54,9 @@ sdcc -o SMSlib_PSGaiden.rel -c -mz80 %OPT% --peep-file peep-rules.txt SMSlib_PSG
 sdcc -o SMSlib_textrenderer.rel -c -mz80 %OPT% --peep-file peep-rules.txt SMSlib_textrenderer.c
 @if %errorlevel% NEQ 0 goto :EOF
 
+sdcc -o SMSlib_textrenderer.rel -c -mz80 %OPT% --peep-file peep-rules.txt SMSlib_readVRAM.c
+@if %errorlevel% NEQ 0 goto :EOF
+
 sdcc -o SMSlib_textrenderer.rel -c -mz80 %OPT% --peep-file peep-rules.txt SMSlib_string.c
 @if %errorlevel% NEQ 0 goto :EOF
 


### PR DESCRIPTION
This is a first iteration, the read code could probably be faster (i.e. how many cycles are required between VDP reads?) and in any case, this has not been tested on real hardware yet.

The use case is that I wanted to implement multiple levels of _overlapping_ popup menus/windows in a game I am working on, and this approach keeps things really simple.

The new SMS_saveTileMapArea function is the opposite of SMS_loadTileMapArea. Before drawing itself, each popup menu uses SMS_saveTileMapArea to save what is beneath it into an appropriately sized buffer which is later passed to SMS_loadTileMapArea to erase the popup.

More optimal access functions, such as memcpy from VRAM, and unsafe variants could be added in the future.