### PR TITLE
Fixed building of examples with SDCC 4.2

### DIFF
--- a/examples/first_test/Makefile
+++ b/examples/first_test/Makefile
@@ -9,7 +9,7 @@ SMSLIB_LIB=$(SMSLIB_BASE)/SMSlib.lib          # Use distributed lib
 #SMSLIB_LIB=$(SMSLIB_BASE)/src/SMSlib.lib      # Use locally compiled lib
 
 CFLAGS=-mz80 -I$(SMSLIB_INCDIR) --peep-file $(PEEP_RULES)
-LDFLAGS=--no-std-crt0 --data-loc 0xC000
+LDFLAGS=-mz80 --no-std-crt0 --data-loc 0xC000
 
 PROGNAME=first
 

--- a/examples/first_test/Makefile.gg
+++ b/examples/first_test/Makefile.gg
@@ -9,7 +9,7 @@ CRT0=$(DEVKITSMS_BASE)/crt0/crt0_sms.rel
 SMSLIB_LIB=$(SMSLIB_BASE)/src/SMSlib_GG.lib      # Use locally compiled lib
 
 CFLAGS=-mz80 -I$(SMSLIB_INCDIR) --peep-file $(PEEP_RULES) -DTARGET_GG
-LDFLAGS=--no-std-crt0 --data-loc 0xC000
+LDFLAGS=-mz80 --no-std-crt0 --data-loc 0xC000
 
 PROGNAME=first
 

--- a/examples/hello_sms/Makefile
+++ b/examples/hello_sms/Makefile
@@ -9,7 +9,7 @@ SMSLIB_LIB=$(SMSLIB_BASE)/SMSlib.lib          # Use distributed lib
 #SMSLIB_LIB=$(SMSLIB_BASE)/src/SMSlib.lib      # Use locally compiled lib
 
 CFLAGS=-mz80 -I$(SMSLIB_INCDIR) --peep-file $(PEEP_RULES)
-LDFLAGS=--no-std-crt0 --data-loc 0xC000
+LDFLAGS=-mz80 --no-std-crt0 --data-loc 0xC000
 
 PROGNAME=hello
 


### PR DESCRIPTION
**Problem:**

SDCC 4.2 gave the following error when linking the examples:

```
sdcc -o first.ihx --no-std-crt0 --data-loc 0xC000 /opt/devkitSMS/crt0/crt0_sms.rel /opt/devkitSMS/SMSlib/SMSlib.lib           main.rel
at 1: warning 117: unknown compiler option '--no-std-crt0' ignored
ASlink-Warning-No definition of area HOME
ASlink-Warning-No definition of area XSEG
ASlink-Warning-No definition of area PSEG

?ASlink-Warning-Undefined Global '___sdcc_call_hl' referenced by module 'SMSlib'
?ASlink-Error-<cannot open> : "/opt/devkitSMS/crt0/crt0_sms.lst"
make: *** [Makefile:27: first.ihx] Error 1
```

**Solution**

Added the `-mz80` flag to the linker flags in examples Makefiles.

Then everything builds and links fine.

Apparently the `--no-std-crt0` flag is port specific and requires z80 to be set as port.

SDCC help text:

```
Special options for the z80 port:
      --callee-saves-bc     Force a called function to always save BC
      --portmode=           Determine PORT I/O mode (z80/z180)
      --asm=                Define assembler name (rgbds/asxxxx/isas/z80asm/gas)
      --codeseg             <name> use this name for the code segment
      --constseg            <name> use this name for the const segment
      --dataseg             <name> use this name for the data segment
      --no-std-crt0         Do not link default crt0.rel
      --reserve-regs-iy     Do not use IY (incompatible with --fomit-frame-pointer)
      --oldralloc           Use old register allocator (deprecated)
      --fno-omit-frame-pointer  Do not omit frame pointer
      --emit-externs        Emit externs list in generated asm
      --legacy-banking      Use legacy method to call banked functions
      --nmos-z80            Generate workaround for NMOS Z80 when saving IFF2
      --sdcccall            Set ABI version for default calling convention
```