### PR TITLE
Add a Makefile for PSGlib

### DIFF
--- a/PSGlib/src/.gitignore
+++ b/PSGlib/src/.gitignore
@@ -1,0 +1,5 @@
+*.lst
+*.asm
+*.rel
+*.lib
+*.sym

--- a/PSGlib/src/Makefile
+++ b/PSGlib/src/Makefile
@@ -1,0 +1,40 @@
+CC=sdcc
+AR=sdar
+
+CFLAGS=-mz80 --max-allocs-per-node 100000
+
+OUTPUT_LIBS=PSGlib.lib PSGlib_MB.lib PSGlib_NOSFX.lib
+SOURCES=PSGlib.c PSGAttenuation.c PSGPlayLoops.c PSGRestoreVolumes.c PSGResume.c
+
+OBJS_STD=$(patsubst %.c,%.rel, $(SOURCES))
+OBJS_MB=$(patsubst %.c,%_MB.rel, $(SOURCES))
+OBJS_NOSFX=$(patsubst %.c,%_NOSFX.rel, $(SOURCES))
+
+ALL: $(OUTPUT_LIBS)
+
+# Library outputs
+PSGlib.lib: $(OBJS_STD)
+	sdar r $@ $^
+
+PSGlib_MB.lib: $(OBJS_MB)
+	sdar r $@ $^
+
+PSGlib_NOSFX.lib: $(OBJS_NOSFX)
+	sdar r $@ $^
+
+
+# Specific rules for some files with particular compilation options or specific
+# to a target.
+
+%.rel: %.c PSGlib_extern.h  PSGlib.h
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+%_MB.rel: %.c PSGlib_extern.h  PSGlib.h
+	$(CC) $(CFLAGS) -c -o $@ $< -DPSGLIB_MULTIBANK
+
+%_NOSFX.rel: %.c PSGlib_extern.h  PSGlib.h
+	$(CC) $(CFLAGS) -c -o $@ $< -DPSGLIB_NOSFXCODE
+
+clean:
+	rm -f $(OUTPUT_LIBS) $(OBJS_STD) $(OBJS_MB) $(OBJS_NOSFX) *.lst *.sym *.asm
+


### PR DESCRIPTION
So while troubleshooting an issue I made a Makefile to easily recompile PSGlib. I thought it might share it here.

I also added a .gitignore to PSGlib/src to ignore the bunch of build files this generates in this directory. (lots of .sym, .rel, .lst and .asm files), etc, which fills the terminal when I type git status). I know some people prefer only one .gitignore at the root of the project, so I made a separate commit. (so it would be easy to cherry-pick the Makefile commit only)