### PR TITLE
Fix NO_SPRITE_CHECKS version of SMS_addTwoAdjoiningSprites_f

### DIFF
--- a/SMSlib/src/SMSlib_twosprites.c
+++ b/SMSlib/src/SMSlib_twosprites.c
@@ -68,7 +68,7 @@ _secondSpriteClipped:
 */
 
 #ifdef NO_SPRITE_CHECKS
-// 1st sdcccall(1) ASM version: 204 CPU cycles
+// 1st sdcccall(1) ASM version: 215 CPU cycles
 void SMS_addTwoAdjoiningSprites_f (unsigned char y, unsigned int x_tile) __naked __preserves_regs(d,e,iyh,iyl) __sdcccall(1) {
   // Y passed in A
   // X passed in D
@@ -87,7 +87,8 @@ void SMS_addTwoAdjoiningSprites_f (unsigned char y, unsigned int x_tile) __naked
     ld (hl),a                        ; write Y again for the second sprite (always as Y-1)
 
     ld hl,#_SpriteTableXN
-    sla c
+    sla c                            ; SpriteNextFree * 2
+    add hl,bc                        ; hl+=SpriteNextFree
     ld (hl),d                        ; write X
     inc hl
     ld (hl),e                        ; write tile number


### PR DESCRIPTION
Without the `add hl,bc`, all calls of this function cause a write the top of SpriteTableXN[0] insted of SpriteTableXN[SpriteNextFree] !


`add hl,bc` is 11 cycles if I am not mistaken. I assumed the cycle count in the description was correct and simply added 11 to it.