### PR TITLE
Support for VSCode and family

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,3 @@
+CompileFlags:
+    Add: [ --include=.sdcc.h, -Wno-tentative-definition-array, -Wno-main-return-type ]
+    Remove: [ -m*, --peep-file ]

--- a/.sdcc.h
+++ b/.sdcc.h
@@ -1,0 +1,9 @@
+#define __z88dk_fastcall
+#define __at(...)
+#define __preserves_regs(...)
+#define __naked
+#define __z88dk_callee
+#define __critical
+#define __interrupt(...)
+#define __sdcccall(...)
+typedef unsigned char __sfr;

--- a/IDE.md
+++ b/IDE.md
@@ -1,0 +1,38 @@
+devkitSMS IDE support
+=====================
+
+### How to set up your devkitSMS project for official VSCode with C/C++ extension:
+
+* copy into your project folder
+  * the folder `ide/.vscode/`
+  * the file `.sdcc.h`
+* edit `.vscode/c_cpp_properties.json`
+  * correct `compilerPath` as needed
+  * set an environment variable `DEVKITSMS_BASE=<your devkitSMS folder>`, or just replace all `${env:DEVKITSMS_BASE}`
+
+Forks of VSCode cannot access the C/C++ extension. Instead try installing the clangd extension and following the instructions below.
+
+### How to generate a compilation database for your devkitSMS project:
+
+Example using bear
+
+* copy the file `ide/.bearconfig` into your project folder
+* in your new `.bearconfig` correct the compilers path as needed
+* add `compile_commands.json` to your project `.gitignore` or equivalent
+* generate the compilation database:
+```sh
+  make clean
+  bear -c .bearconfig -- make
+```
+* regenerate whenever you add a new source file to your project
+
+[Other generation options](https://sarcasm.github.io/notes/dev/compilation-database.html#how-to-generate-a-json-compilation-database)
+
+### How to set up your devkitSMS project for clangd:
+
+* copy files into your project folder:
+  * `.clangd`
+  * `.sdcc.h`
+* have clangd run with arguments: `--query-driver=/usr/bin/sdcc --compile-commands-dir=$YOUR_PROJECT_DIR"`
+  * correct `/usr/bin/sdcc` to your compiler path as needed
+  * For example in VSCode with clangd extension, copy the folder `ide/.vscode/` into your project folder, or copy the `clangd.arguments` setting from `ide/.vscode/settings.json` into your project's existing `.vscode/settings.json`

--- a/ide/.bearconfig
+++ b/ide/.bearconfig
@@ -1,0 +1,3 @@
+schema: "4.1"
+compilers:
+  - path: /usr/bin/sdcc

--- a/ide/.vscode/c_cpp_properties.json
+++ b/ide/.vscode/c_cpp_properties.json
@@ -1,0 +1,23 @@
+{
+    "configurations": [
+        {
+            "name": "SMS",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "${env:DEVKITSMS_BASE}/SMSlib/src",
+                "${env:DEVKITSMS_BASE}/PSGlib/src",
+                "${env:DEVKITSMS_BASE}/SGlib/src",
+                "${env:DEVKITSMS_BASE}/MBMlib/src"
+            ],
+            "defines": [],
+            "cStandard": "c99",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "${default}",
+            "compilerPath": "/usr/bin/sdcc",
+            "forcedInclude": [
+                ".sdcc.h"
+            ]
+        }
+    ],
+    "version": 4
+}

--- a/ide/.vscode/settings.json
+++ b/ide/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "clangd.arguments": [
+    "--query-driver=/usr/bin/sdcc",
+    "--compile-commands-dir=${workspaceFolder}"
+  ]
+}


### PR DESCRIPTION
Lets you setup VSCode family IDEs to find and parse devkitSMS headers.

The remaining problem is how to make both `__interrupt(n)` and `__interrupt` (non-function) invisible to Intellisense. SGlib.h uses both if not targeting Colecovision.